### PR TITLE
Update Username Display and Related Messaging

### DIFF
--- a/pages/api/lib/_helpers.ts
+++ b/pages/api/lib/_helpers.ts
@@ -3,6 +3,7 @@ import { createHash, createHmac } from 'crypto';
 import { connectToDatabase } from '@/pages/api/lib/_connectToDatabase';
 import memoize from 'fast-memoize';
 import { Member, telegramTypes, UpdateArchive } from './_types';
+import { ANONYMOUS } from './_locale.en';
 
 const appendAuthor = (caption = '', postfix = '', createdAt = '') => {
   let response = '';
@@ -181,3 +182,15 @@ export const getSubmissionDates = () => {
 
   return { previousSubmitTimestamp, nextSubmitTimestamp };
 };
+
+export const getDisplayName = (user: Member) => {
+  const { first_name, last_name, username } = user.about;
+  if (username) {
+    return username;
+  }
+  const userFullName = `${first_name || ''} ${last_name || ''}`.trim();
+  if (userFullName !== '') {
+    return userFullName;
+  }
+  return ANONYMOUS;
+}

--- a/pages/api/lib/_helpers.ts
+++ b/pages/api/lib/_helpers.ts
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import { createHash, createHmac } from 'crypto';
 import { connectToDatabase } from '@/pages/api/lib/_connectToDatabase';
 import memoize from 'fast-memoize';
-import { telegramTypes, UpdateArchive } from './_types';
+import { Member, telegramTypes, UpdateArchive } from './_types';
 
 const appendAuthor = (caption = '', postfix = '', createdAt = '') => {
   let response = '';
@@ -181,3 +181,15 @@ export const getSubmissionDates = () => {
 
   return { previousSubmitTimestamp, nextSubmitTimestamp };
 };
+
+export const getDisplayName = (user: Member) => {
+  const { first_name, last_name, username } = user.about;
+  if (username) {
+    return username;
+  }
+  const userFullName = `${first_name || ''} ${last_name || ''}`.trim();
+  if (userFullName !== '') {
+    return userFullName;
+  }
+  return 'Anonymous';
+}

--- a/pages/api/lib/_helpers.ts
+++ b/pages/api/lib/_helpers.ts
@@ -181,15 +181,3 @@ export const getSubmissionDates = () => {
 
   return { previousSubmitTimestamp, nextSubmitTimestamp };
 };
-
-export const getDisplayName = (user: Member) => {
-  const { first_name, last_name, username } = user.about;
-  if (username) {
-    return username;
-  }
-  const userFullName = `${first_name || ''} ${last_name || ''}`.trim();
-  if (userFullName !== '') {
-    return userFullName;
-  }
-  return 'Anonymous';
-}

--- a/pages/api/lib/_locale.en.ts
+++ b/pages/api/lib/_locale.en.ts
@@ -83,7 +83,6 @@ Click /subscribe to join!`;
     users[0]
   )} is the only member subscribed to this group.
 
-  
 Click /subscribe to join them!`;
 
   const multipleUsersMessage = `At update time, one of the following members will randomly be awarded the opportunity to submit the next update:

--- a/pages/api/lib/_locale.en.ts
+++ b/pages/api/lib/_locale.en.ts
@@ -1,16 +1,7 @@
-import { Member } from "./_types";
+import { getDisplayName } from './_helpers';
+import { Member } from './_types';
 
-export const getDisplayName = (user: Member) => {
-  const { first_name, last_name, username } = user.about;
-  if (username) {
-    return username;
-  }
-  const userFullName = `${first_name || ''} ${last_name || ''}`.trim();
-  if (userFullName !== '') {
-    return userFullName;
-  }
-  return 'Anonymous';
-}
+export const ANONYMOUS = 'Anonymous';
 
 export const START_MESSAGE = `To get started, add this bot to your chat and type /subscribe to subscribe them to your updates.
 
@@ -75,18 +66,33 @@ export const WINNER_GROUP_MESSAGE = (user: Member) =>
 Updates from others will be ignored.`;
 
 export const WINNER_DM_MESSAGE = (groups: Array<string>) =>
-  `🎲 We rolled the dice for you, and by golly, you won! 🎲
+  `🎲 We rolled the dice for you and by golly - you won! 🎲
 
 ${getGroupsMessage(groups)}`;
 
-export const NO_WINNING_GROUPS_MESSAGE = `You haven't won the update lottery in any groups yet! Check back tomorrow 🤞🏻
+export const NO_WINNING_GROUPS_MESSAGE = `You haven't won the update lottery in any groups yet! Check back tomorrow 🤞
 
 Your update was not saved.`;
 
-export const SUBSCRIBERS_MESSAGE = (
-  users: Array<Member>
-) => `A member, at random, will be awarded the opportunity to submit an update for this group. The member${users.length > 1 ? 's' : ''} currently subscribed in this chat:
+export const SUBSCRIBERS_MESSAGE = (users: Array<Member>) => {
+  const noUsersMessage = `There are no subscribers yet.
+
+Click /subscribe to join!`;
+
+  const singleUserMessage = `Currently ${getDisplayName(
+    users[0]
+  )} is the only member subscribed to this group.
+
+  
+Click /subscribe to join them!`;
+
+  const multipleUsersMessage = `At update time, one of the following members will randomly be awarded the opportunity to submit the next update:
 
 ${users.map((u) => `• ${getDisplayName(u)}`).join('\n')}
 
-To have a chance of being chosen, type /subscribe to join!`;
+To participate, click /subscribe and you might be chosen next!`;
+
+  if (users.length === 0) return noUsersMessage;
+  if (users.length === 1) return singleUserMessage;
+  return multipleUsersMessage;
+};

--- a/pages/api/lib/_locale.en.ts
+++ b/pages/api/lib/_locale.en.ts
@@ -1,5 +1,16 @@
-import { getDisplayName } from "./_helpers";
 import { Member } from "./_types";
+
+export const getDisplayName = (user: Member) => {
+  const { first_name, last_name, username } = user.about;
+  if (username) {
+    return username;
+  }
+  const userFullName = `${first_name || ''} ${last_name || ''}`.trim();
+  if (userFullName !== '') {
+    return userFullName;
+  }
+  return 'Anonymous';
+}
 
 export const START_MESSAGE = `To get started, add this bot to your chat and type /subscribe to subscribe them to your updates.
 

--- a/pages/api/lib/_locale.en.ts
+++ b/pages/api/lib/_locale.en.ts
@@ -1,3 +1,6 @@
+import { getDisplayName } from "./_helpers";
+import { Member } from "./_types";
+
 export const START_MESSAGE = `To get started, add this bot to your chat and type /subscribe to subscribe them to your updates.
 
 Afterwards, post a message here and it will automatically be sent to your chat at 11:00 am. You will receive a few reminders if you do not submit your standup before 8:00 am the day of.
@@ -56,8 +59,8 @@ If you want to change your update, edit your last message.
 
 ${getGroupsMessage(groups)}`;
 
-export const WINNER_GROUP_MESSAGE = (username: string) =>
-  `🎲 ${username} has won! They've been chosen to send an update to this group.
+export const WINNER_GROUP_MESSAGE = (user: Member) =>
+  `🎲 ${getDisplayName(user)} has won! They've been chosen to send an update to this group.
 Updates from others will be ignored.`;
 
 export const WINNER_DM_MESSAGE = (groups: Array<string>) =>
@@ -70,9 +73,9 @@ export const NO_WINNING_GROUPS_MESSAGE = `You haven't won the update lottery in 
 Your update was not saved.`;
 
 export const SUBSCRIBERS_MESSAGE = (
-  usernames: Array<string>
-) => `Stoodbot member${usernames.length > 1 ? 's' : ''} in this chat:
+  users: Array<Member>
+) => `A member, at random, will be awarded the opportunity to submit an update for this group. The member${users.length > 1 ? 's' : ''} currently subscribed in this chat:
 
-${usernames.map((g) => `• ${g}`).join('\n')}
+${users.map((u) => `• ${getDisplayName(u)}`).join('\n')}
 
-Type /subscribe to join!`;
+To have a chance of being chosen, type /subscribe to join!`;

--- a/pages/api/lib/_lottery.ts
+++ b/pages/api/lib/_lottery.ts
@@ -61,8 +61,6 @@ export const setWinners = async () => {
   // These users should all get a reminder. When they post, it'll send to the groups they're winners in
   Object.keys(lotteryWinners).forEach((userId) => {
     const user: Member = users.find((u: Member) => u.userId === Number(userId));
-    const userFullName = `${user.about.first_name || ''} ${user.about.last_name || ''}`.trim();
-    const userDisplayName = user.about.username ? user.about.username : userFullName;
     const winningGroups = lotteryWinners[userId];
     const groups = user.groups.filter((g) => winningGroups.includes(g.chatId));
     const groupTitles = groups.map((group) => group.title);
@@ -84,7 +82,7 @@ export const setWinners = async () => {
         )
       );
 
-      promises.push(sendMsg(WINNER_GROUP_MESSAGE(userDisplayName), chatId));
+      promises.push(sendMsg(WINNER_GROUP_MESSAGE(user), chatId));
     });
 
     promises.push(sendMsg(WINNER_DM_MESSAGE(groupTitles), user.userId));

--- a/pages/api/lib/_lottery.ts
+++ b/pages/api/lib/_lottery.ts
@@ -61,7 +61,7 @@ export const setWinners = async () => {
   // These users should all get a reminder. When they post, it'll send to the groups they're winners in
   Object.keys(lotteryWinners).forEach((userId) => {
     const user: Member = users.find((u: Member) => u.userId === Number(userId));
-    const userFullName = `${user.about.first_name} ${user.about.last_name}`.trim();
+    const userFullName = `${user.about.first_name || ''} ${user.about.last_name || ''}`.trim();
     const userDisplayName = user.about.username ? user.about.username : userFullName;
     const winningGroups = lotteryWinners[userId];
     const groups = user.groups.filter((g) => winningGroups.includes(g.chatId));

--- a/pages/api/standup.ts
+++ b/pages/api/standup.ts
@@ -208,15 +208,15 @@ const getMembers = async (
   const { db } = await connectToDatabase();
   const users: Array<Member> = await db.collection('users').find({}).toArray();
 
-  const usernames = [];
+  const members: Member[] = [];
 
   users.forEach((u) =>
     u.groups.forEach(
-      (g) => g.chatId === chatId && usernames.push(u.about.username)
+      (g) => g.chatId === chatId && members.push(u)
     )
   );
 
-  return await sendMsg(SUBSCRIBERS_MESSAGE(usernames), chatId, messageId);
+  return await sendMsg(SUBSCRIBERS_MESSAGE(members), chatId, messageId);
 };
 
 const addToStandupGroup = async (


### PR DESCRIPTION
Well, since my last fix was so well received, I decided to make it work more better hopefully. I noticed `/members` doesn't respect first/last names and I looked through the code and couldn't find any other place that seemed like it needed updating. There is one place that's using username to query the DB, but it seems like it's working fine with people who don't have a username set so far so 🦐 